### PR TITLE
Revise documentation cuba-platform/front-generator#60

### DIFF
--- a/create-nojekyll.js
+++ b/create-nojekyll.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+
+fs.writeFileSync('docs/.nojekyll', '');
+console.log('Created .nojekyll file');

--- a/docs/classes/_cuba_.cubaapp.html
+++ b/docs/classes/_cuba_.cubaapp.html
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L113">cuba.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L113">cuba.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L116">cuba.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L116">cuba.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L121">cuba.ts:121</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L121">cuba.ts:121</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L119">cuba.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L119">cuba.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">enums<wbr>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_model_.enuminfo.html" class="tsd-signature-type">EnumInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L108">cuba.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L108">cuba.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">enums<wbr>Loading<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L112">cuba.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L112">cuba.ts:112</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">locale<wbr>Change<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L113">cuba.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L113">cuba.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">messages<wbr>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_model_.entitymessages.html" class="tsd-signature-type">EntityMessages</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L107">cuba.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L107">cuba.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">messages<wbr>Loading<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L111">cuba.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L111">cuba.ts:111</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L115">cuba.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L115">cuba.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 					<div class="tsd-signature tsd-kind-icon">rest<wbr>Client<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L117">cuba.ts:117</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L117">cuba.ts:117</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">rest<wbr>Client<wbr>Secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L118">cuba.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L118">cuba.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">storage<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Storage</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L120">cuba.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L120">cuba.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Expiry<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">function</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L110">cuba.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L110">cuba.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">LOCALE_<wbr>STORAGE_<wbr>KEY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;cubaLocale&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L105">cuba.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L105">cuba.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -356,7 +356,7 @@
 					<div class="tsd-signature tsd-kind-icon">NOT_<wbr>SUPPORTED_<wbr>BY_<wbr>API_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;Not supported by current REST API version&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L101">cuba.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L101">cuba.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -366,7 +366,7 @@
 					<div class="tsd-signature tsd-kind-icon">REST_<wbr>TOKEN_<wbr>STORAGE_<wbr>KEY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;cubaAccessToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L103">cuba.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L103">cuba.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER_<wbr>NAME_<wbr>STORAGE_<wbr>KEY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;cubaUserName&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L104">cuba.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L104">cuba.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -394,7 +394,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L132">cuba.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L132">cuba.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -402,7 +402,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L137">cuba.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L137">cuba.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -426,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L124">cuba.ts:124</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L124">cuba.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L128">cuba.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L128">cuba.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -460,7 +460,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L501">cuba.ts:501</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L501">cuba.ts:501</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">object</span></h4>
@@ -482,7 +482,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L505">cuba.ts:505</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L505">cuba.ts:505</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L436">cuba.ts:436</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L436">cuba.ts:436</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -522,7 +522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L513">cuba.ts:513</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L513">cuba.ts:513</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L250">cuba.ts:250</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L250">cuba.ts:250</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -574,7 +574,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L246">cuba.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L246">cuba.ts:246</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -603,7 +603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L357">cuba.ts:357</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L357">cuba.ts:357</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -641,7 +641,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L452">cuba.ts:452</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L452">cuba.ts:452</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -670,7 +670,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L353">cuba.ts:353</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L353">cuba.ts:353</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -696,7 +696,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L349">cuba.ts:349</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L349">cuba.ts:349</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -713,7 +713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L337">cuba.ts:337</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L337">cuba.ts:337</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -736,7 +736,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L341">cuba.ts:341</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L341">cuba.ts:341</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -759,7 +759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L345">cuba.ts:345</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L345">cuba.ts:345</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -782,7 +782,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L264">cuba.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L264">cuba.ts:264</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -820,7 +820,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L488">cuba.ts:488</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L488">cuba.ts:488</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -843,7 +843,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L495">cuba.ts:495</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L495">cuba.ts:495</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -866,7 +866,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L186">cuba.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L186">cuba.ts:186</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -901,7 +901,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L318">cuba.ts:318</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L318">cuba.ts:318</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -924,7 +924,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L194">cuba.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L194">cuba.ts:194</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -959,7 +959,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L237">cuba.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L237">cuba.ts:237</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1002,7 +1002,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L304">cuba.ts:304</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L304">cuba.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1028,7 +1028,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L313">cuba.ts:313</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L313">cuba.ts:313</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1057,7 +1057,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L308">cuba.ts:308</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L308">cuba.ts:308</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1083,7 +1083,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L328">cuba.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L328">cuba.ts:328</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1106,7 +1106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L300">cuba.ts:300</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L300">cuba.ts:300</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1129,7 +1129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L149">cuba.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L149">cuba.ts:149</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1169,7 +1169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L172">cuba.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L172">cuba.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1186,7 +1186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L426">cuba.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L426">cuba.ts:426</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1209,7 +1209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L416">cuba.ts:416</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L416">cuba.ts:416</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1232,7 +1232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L431">cuba.ts:431</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L431">cuba.ts:431</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1255,7 +1255,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L421">cuba.ts:421</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L421">cuba.ts:421</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1278,7 +1278,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L274">cuba.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L274">cuba.ts:274</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1316,7 +1316,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L296">cuba.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L296">cuba.ts:296</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1348,7 +1348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L283">cuba.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L283">cuba.ts:283</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1386,7 +1386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L462">cuba.ts:462</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L462">cuba.ts:462</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1410,7 +1410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L480">cuba.ts:480</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L480">cuba.ts:480</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1454,7 +1454,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L176">cuba.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L176">cuba.ts:176</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1477,7 +1477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L208">cuba.ts:208</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L208">cuba.ts:208</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1515,7 +1515,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L218">cuba.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L218">cuba.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1553,7 +1553,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L443">cuba.ts:443</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L443">cuba.ts:443</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_storage_.defaultstorage.html
+++ b/docs/classes/_storage_.defaultstorage.html
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L6">storage.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L6">storage.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -158,7 +158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L8">storage.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L8">storage.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L12">storage.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L12">storage.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L16">storage.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L16">storage.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L23">storage.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L23">storage.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L27">storage.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L27">storage.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/storage.ts#L31">storage.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/storage.ts#L31">storage.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/enums/_model_.permissiontype.html
+++ b/docs/enums/_model_.permissiontype.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENTITY_<wbr>ATTR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ENTITY_ATTR&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L55">model.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L55">model.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENTITY_<wbr>OP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ENTITY_OP&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L54">model.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L54">model.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">SCREEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SCREEN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L53">model.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L53">model.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">SPECIFIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SPECIFIC&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L56">model.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L56">model.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">UI<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;UI&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L57">model.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L57">model.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/_model_.predefinedview.html
+++ b/docs/enums/_model_.predefinedview.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">BASE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;_base&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L110">model.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L110">model.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">LOCAL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;_local&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L109">model.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L109">model.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">MINIMAL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;_minimal&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L108">model.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L108">model.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/_model_.roletype.html
+++ b/docs/enums/_model_.roletype.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">DENYING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;DENYING&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L75">model.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L75">model.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">READONLY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;READONLY&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L74">model.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L74">model.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">STANDARD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;STANDARD&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L72">model.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L72">model.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">STRICTLY_<wbr>DENYING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;STRICTLY_DENYING&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L76">model.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L76">model.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">SUPER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;SUPER&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L73">model.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L73">model.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_cuba_.appconfig.html
+++ b/docs/interfaces/_cuba_.appconfig.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L62">cuba.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L62">cuba.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L75">cuba.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L75">cuba.ts:75</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L66">cuba.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L66">cuba.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L63">cuba.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L63">cuba.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">rest<wbr>Client<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L64">cuba.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L64">cuba.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">rest<wbr>Client<wbr>Secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L65">cuba.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L65">cuba.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">storage<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Storage</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L67">cuba.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L67">cuba.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_cuba_.entitiesloadoptions.html
+++ b/docs/interfaces/_cuba_.entitiesloadoptions.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L91">cuba.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L91">cuba.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L92">cuba.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L92">cuba.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">sort<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L90">cuba.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L90">cuba.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">view<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L89">cuba.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L89">cuba.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_cuba_.fetchoptions.html
+++ b/docs/interfaces/_cuba_.fetchoptions.html
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">handle<wbr>As<span class="tsd-signature-symbol">:</span> <a href="../modules/_cuba_.html#contenttype" class="tsd-signature-type">ContentType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L85">cuba.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L85">cuba.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_cuba_.loginoptions.html
+++ b/docs/interfaces/_cuba_.loginoptions.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L96">cuba.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L96">cuba.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_cuba_.responseerror.html
+++ b/docs/interfaces/_cuba_.responseerror.html
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L79">cuba.ts:79</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L79">cuba.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_filter_.condition.html
+++ b/docs/interfaces/_filter_.condition.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">operator<span class="tsd-signature-symbol">:</span> <a href="../modules/_filter_.html#operatortype" class="tsd-signature-type">OperatorType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L17">filter.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L17">filter.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L16">filter.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L16">filter.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L18">filter.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L18">filter.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_filter_.conditionsgroup.html
+++ b/docs/interfaces/_filter_.conditionsgroup.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">conditions<span class="tsd-signature-symbol">:</span> <a href="_filter_.condition.html" class="tsd-signature-type">Condition</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L12">filter.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L12">filter.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">group<span class="tsd-signature-symbol">:</span> <a href="../modules/_filter_.html#grouptype" class="tsd-signature-type">GroupType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L11">filter.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L11">filter.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_filter_.entityfilter.html
+++ b/docs/interfaces/_filter_.entityfilter.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">conditions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="_filter_.condition.html" class="tsd-signature-type">Condition</a><span class="tsd-signature-symbol"> | </span><a href="_filter_.conditionsgroup.html" class="tsd-signature-type">ConditionsGroup</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L7">filter.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L7">filter.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.entitieswithcount.html
+++ b/docs/interfaces/_model_.entitieswithcount.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L16">model.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L16">model.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_model_.html#serializedentity" class="tsd-signature-type">SerializedEntity</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L15">model.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L15">model.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.enuminfo.html
+++ b/docs/interfaces/_model_.enuminfo.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L95">model.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L95">model.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">values<span class="tsd-signature-symbol">:</span> <a href="_model_.enumvalueinfo.html" class="tsd-signature-type">EnumValueInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L96">model.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L96">model.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.enumvalueinfo.html
+++ b/docs/interfaces/_model_.enumvalueinfo.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">caption<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L91">model.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L91">model.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L90">model.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L90">model.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L89">model.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L89">model.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.metaclassinfo.html
+++ b/docs/interfaces/_model_.metaclassinfo.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">entity<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L31">model.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L31">model.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="_model_.metapropertyinfo.html" class="tsd-signature-type">MetaPropertyInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L32">model.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L32">model.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.metapropertyinfo.html
+++ b/docs/interfaces/_model_.metapropertyinfo.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">attribute<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_.html#attributetype" class="tsd-signature-type">AttributeType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L26">model.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L26">model.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">cardinality<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_.html#cardinality" class="tsd-signature-type">Cardinality</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L27">model.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L27">model.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L25">model.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L25">model.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Transient<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L24">model.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L24">model.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">mandatory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L22">model.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L22">model.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L20">model.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L20">model.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">read<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L23">model.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L23">model.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L21">model.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L21">model.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.permissioninfo.html
+++ b/docs/interfaces/_model_.permissioninfo.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">int<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L68">model.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L68">model.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">target<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L66">model.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L66">model.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/_model_.permissiontype.html" class="tsd-signature-type">PermissionType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L65">model.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L65">model.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_.html#basepermissionvalue" class="tsd-signature-type">BasePermissionValue</a><span class="tsd-signature-symbol"> | </span><a href="../modules/_model_.html#entityattrpermissionvalue" class="tsd-signature-type">EntityAttrPermissionValue</a><span class="tsd-signature-symbol"> | </span><a href="../modules/_model_.html#uipermissionvalue" class="tsd-signature-type">UiPermissionValue</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L67">model.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L67">model.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.roleinfo.html
+++ b/docs/interfaces/_model_.roleinfo.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">role<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/_model_.roletype.html" class="tsd-signature-type">RoleType</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L80">model.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L80">model.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.rolesinfo.html
+++ b/docs/interfaces/_model_.rolesinfo.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">permissions<span class="tsd-signature-symbol">:</span> <a href="_model_.permissioninfo.html" class="tsd-signature-type">PermissionInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L84">model.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L84">model.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">roles<span class="tsd-signature-symbol">:</span> <a href="_model_.roleinfo.html" class="tsd-signature-type">RoleInfo</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L85">model.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L85">model.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.serializedentityprops.html
+++ b/docs/interfaces/_model_.serializedentityprops.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">_entity<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L8">model.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L8">model.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">_instance<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L9">model.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L9">model.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.userinfo.html
+++ b/docs/interfaces/_model_.userinfo.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">_instance<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L46">model.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L46">model.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L43">model.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L43">model.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L39">model.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L39">model.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L36">model.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L36">model.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">language<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L45">model.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L45">model.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L41">model.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L41">model.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L47">model.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L47">model.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">login<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L37">model.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L37">model.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">middle<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L40">model.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L40">model.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L38">model.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L38">model.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">position<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L42">model.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L42">model.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Zone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L44">model.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L44">model.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_model_.view.html
+++ b/docs/interfaces/_model_.view.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">entity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L103">model.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L103">model.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L102">model.ts:102</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L102">model.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="../modules/_model_.html#viewproperty" class="tsd-signature-type">ViewProperty</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L104">model.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L104">model.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_cuba_.html
+++ b/docs/modules/_cuba_.html
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">Content<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"text"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"json"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"blob"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"raw"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L82">cuba.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L82">cuba.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">apps<span class="tsd-signature-symbol">:</span> <a href="../classes/_cuba_.cubaapp.html" class="tsd-signature-type">CubaApp</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L20">cuba.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L20">cuba.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L42">cuba.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L42">cuba.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L520">cuba.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L520">cuba.ts:520</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L27">cuba.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L27">cuba.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L528">cuba.ts:528</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L528">cuba.ts:528</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/cuba.ts#L52">cuba.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/cuba.ts#L52">cuba.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_filter_.html
+++ b/docs/modules/_filter_.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Group<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"AND"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"OR"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L4">filter.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L4">filter.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Operator<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"&#x3D;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&gt;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&gt;&#x3D;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&lt;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&lt;&#x3D;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"&lt;&gt;"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"startsWith"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"endsWith"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"contains"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"doesNotContain"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"in"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"notIn"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"notEmpty"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/filter.ts#L1">filter.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/filter.ts#L1">filter.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_model_.html
+++ b/docs/modules/_model_.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Attribute<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"DATATYPE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ENUM"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ASSOCIATION"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"COMPOSITION"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L3">model.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L3">model.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Base<wbr>Permission<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"DENY"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ALLOW"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L60">model.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L60">model.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cardinality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"NONE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ONE_TO_ONE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MANY_TO_ONE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"ONE_TO_MANY"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MANY_TO_MANY"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L1">model.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L1">model.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Entity<wbr>Attr<wbr>Permission<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"DENY"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"VIEW"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"MODIFY"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L61">model.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L61">model.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">Entity<wbr>Operation<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"create"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"read"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"update"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"delete"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L50">model.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L50">model.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">Property<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"string"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"int"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"double"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"decimal"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"date"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"time"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"dateTime"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"boolean"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L5">model.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L5">model.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">Serialized<wbr>Entity&lt;T&gt;<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_model_.serializedentityprops.html" class="tsd-signature-type">SerializedEntityProps</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L12">model.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L12">model.ts:12</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ui<wbr>Permission<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"HIDE"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"READ_ONLY"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"SHOW"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L62">model.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L62">model.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">View<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/model.ts#L99">model.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/model.ts#L99">model.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_security_.html
+++ b/docs/modules/_security_.html
@@ -95,7 +95,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/security.ts#L22">security.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/security.ts#L22">security.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/security.ts#L92">security.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/security.ts#L92">security.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/security.ts#L76">security.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/security.ts#L76">security.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/security.ts#L115">security.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/security.ts#L115">security.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/security.ts#L51">security.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/security.ts#L51">security.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_util_.html
+++ b/docs/modules/_util_.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Buffer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/util.ts#L1">util.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/util.ts#L1">util.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/util.ts#L2">util.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/util.ts#L2">util.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/util.ts#L4">util.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/util.ts#L4">util.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/util.ts#L16">util.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/util.ts#L16">util.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/34eac8f/src/util.ts#L25">util.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/cuba-platform/cuba-rest-js/blob/204c606/src/util.ts#L25">util.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compile": "tsc",
     "types:browser": "tsc --declarationDir dist-browser --emitDeclarationOnly true",
     "dist": "npm run compile && browserify --standalone cuba dist-node/cuba.js > dist-browser/cuba.js",
-    "generate-docs": "typedoc --module commonjs --out docs src"
+    "generate-docs": "typedoc --module commonjs --out docs src && node create-nojekyll.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `generate-docs` script will now add .nojekyll file to the docs folder
  which will allow pages with filenames starting with an underscore
  to be available in GitHub Pages
- Generated the docs based on latest version of the sources